### PR TITLE
Secp256k1: Renamings to follow RustCrypto's `k256` crate naming converntions

### DIFF
--- a/examples/curves/Secp256k1.sol
+++ b/examples/curves/Secp256k1.sol
@@ -4,33 +4,39 @@ pragma solidity ^0.8.16;
 import {Script} from "forge-std/Script.sol";
 import {console2 as console} from "forge-std/console2.sol";
 
-import {Secp256k1, PrivateKey, PublicKey} from "src/curves/Secp256k1.sol";
-import {Secp256k1Arithmetic, Point, JacobianPoint} from "src/curves/Secp256k1Arithmetic.sol";
+import {Secp256k1, SecretKey, PublicKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1Arithmetic, Point, ProjectivePoint} from 
+    "src/curves/Secp256k1Arithmetic.sol";
 
 contract Secp256k1Example is Script {
-    using Secp256k1 for PrivateKey;
+    using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
 
     function run() public {
-        // Create new cryptographically sound private key.
-        PrivateKey privKey = Secp256k1.newPrivateKey();
+        // Create new cryptographically sound secret key.
+        SecretKey sk = Secp256k1.newSecretKey();
+        assert(sk.isValid());
 
         // Derive public key.
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
+        assert(pk.isValid());
 
         // Arithmetic types.
-        // into() -> no memory allocation, to() -> new memory allocation
-        Point memory point = pubKey.intoPoint();
-        JacobianPoint memory jacPoint = pubKey.toJacobianPoint();
+        // into***() -> no memory allocation
+        // to***() -> new memory allocation
+        Point memory point = pk.intoPoint();
+        ProjectivePoint memory jPoint = pk.toProjectivePoint();
 
-        // Print some stuff.
-        console.log("Address", pubKey.toAddress());
-        console.log("Parity", pubKey.yParity());
-        console.logBytes32(pubKey.toHash());
-        console.log("Valid", pubKey.isValid());
+        // Derive common constructs.
+        address addr = pk.toAddress();
+        bytes32 digest = pk.toHash();
+        uint yParity = pk.yParity();
 
-        // Serialization.
-        privKey = Secp256k1.privateKeyFromBytes(privKey.toBytes());
-        pubKey = Secp256k1.publicKeyFromBytes(pubKey.toBytes());
+        // ABI serialization.
+        sk = Secp256k1.secretKeyFromBytes(sk.toBytes());
+        pk = Secp256k1.publicKeyFromBytes(pk.toBytes());
+
+        // SEC1 serialization.
+        pk = Secp256k1.publicKeyFromEncoded(pk.toEncoded());
     }
 }

--- a/examples/signatures/ECDSA.sol
+++ b/examples/signatures/ECDSA.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.16;
 import {Script} from "forge-std/Script.sol";
 import {console2 as console} from "forge-std/console2.sol";
 
-import {Secp256k1, PrivateKey, PublicKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1, SecretKey, PublicKey} from "src/curves/Secp256k1.sol";
 
 import {ECDSA, Signature} from "src/signatures/ECDSA.sol";
 
 contract ECDSAExample is Script {
-    using Secp256k1 for PrivateKey;
+    using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
 
     using ECDSA for address;
@@ -20,16 +20,17 @@ contract ECDSAExample is Script {
     function signAndVerify() public {
         bytes memory message = bytes("crysol <3");
 
-        // Create a cryptographically secure private key.
-        PrivateKey privKey = Secp256k1.newPrivateKey();
+        // Create new cryptographically sound secret key.
+        SecretKey sk = Secp256k1.newSecretKey();
+        assert(sk.isValid());
 
         // Sign message via ECDSA.
-        Signature memory sig = privKey.sign(message);
+        Signature memory sig = sk.sign(message);
 
         // Verify signature via public key or address.
-        PublicKey memory pubKey = privKey.toPublicKey();
-        address addr = pubKey.toAddress();
-        require(pubKey.verify(message, sig), "Signature invalid");
+        PublicKey memory pk = sk.toPublicKey();
+        require(sk.toPublicKey().verify(message, sig), "Signature invalid");
+        address addr = pk.toAddress();
         require(addr.verify(message, sig), "Signature invalid");
 
         // Print signature to stdout.

--- a/examples/signatures/ECDSA.sol
+++ b/examples/signatures/ECDSA.sol
@@ -13,7 +13,7 @@ contract ECDSAExample is Script {
     using Secp256k1 for PublicKey;
 
     using ECDSA for address;
-    using ECDSA for PrivateKey;
+    using ECDSA for SecretKey;
     using ECDSA for PublicKey;
     using ECDSA for Signature;
 

--- a/examples/signatures/Schnorr.sol
+++ b/examples/signatures/Schnorr.sol
@@ -4,30 +4,32 @@ pragma solidity ^0.8.16;
 import {Script} from "forge-std/Script.sol";
 import {console2 as console} from "forge-std/console2.sol";
 
-import {Secp256k1, PrivateKey, PublicKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1, SecretKey, PublicKey} from "src/curves/Secp256k1.sol";
 
 import {Schnorr, Signature} from "src/signatures/Schnorr.sol";
 
 contract SchnorrExample is Script {
-    using Secp256k1 for PrivateKey;
+    using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
 
-    using Schnorr for PrivateKey;
+    using Schnorr for SecretKey;
     using Schnorr for PublicKey;
     using Schnorr for Signature;
 
     function signAndVerify() public {
         bytes memory message = bytes("crysol <3");
 
-        // Create a cryptographically secure private key.
-        PrivateKey privKey = Secp256k1.newPrivateKey();
+        // Create a cryptographically secure secret key.
+        SecretKey sk = Secp256k1.newSecretKey();
+        assert(sk.isValid());
 
-        // Sign message via Schnorr.
-        Signature memory sig = privKey.sign(message);
+        // Create Schnorr signature.
+        Signature memory sig = sk.sign(message);
+        assert(!sig.isMalleable());
 
         // Verify signature.
-        PublicKey memory pubKey = privKey.toPublicKey();
-        require(pubKey.verify(message, sig), "Signature invalid");
+        PublicKey memory pk = sk.toPublicKey();
+        require(pk.verify(message, sig), "Could not verify own signature");
 
         // Print signature to stdout.
         console.log(sig.toString());

--- a/src/Random.sol
+++ b/src/Random.sol
@@ -44,8 +44,8 @@ library Random {
 
         bytes memory result = vm.ffi(inputs);
 
-        // Note that while parts of `cast wallet new` output is constant it
-        // always contains the new wallet's private key and is therefore unique.
+        // Note that while parts of `cast wallet new` output are constant it
+        // always contains the new wallet's secret key and is therefore unique.
         //
         // Note that cast is trusted to create cryptographically secure wallets.
         return uint(keccak256(result));

--- a/src/curves/Secp256k1.sol
+++ b/src/curves/Secp256k1.sol
@@ -9,9 +9,6 @@
 */
 
 // TODO:
-//  - [X] Rename JacobianPoint to ProjectivePoint
-//  - [X] Rename PointAtInfinity to Identity?
-//      - Maybe both? Basically type alias?
 //  - [ ] Complete addition formula from Renes-Costello-Batina 2015?
 //      - See https://eprint.iacr.org/2015/1060 Algorithm 7 + 8
 //      - For double Algorithm 9
@@ -21,8 +18,6 @@
 //          - toEncodedPoint() -> SEC1 encoded ("normal")
 //          - toCompressedEncodedPoint() -> compressed SEC1 encoded
 //      - TODO: Note that identity case not implemented!!!!
-//
-//  - [X] Use SecretKey instead of PrivateKey?
 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
@@ -74,8 +69,8 @@ type SecretKey is uint;
  *
  *          SecretKey sk = Secp256k1.newSecretKey();
  *
- *          PublicKey memory pubKey = sk.toPublicKey();
- *          assert(pubKey.isValid());
+ *          PublicKey memory pk = sk.toPublicKey();
+ *          assert(pk.isValid());
  *      }
  *      ```
  */
@@ -97,6 +92,7 @@ library Secp256k1 {
     using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
     using Secp256k1 for Point;
+
     using Secp256k1Arithmetic for Point;
 
     // ~~~~~~~ Prelude ~~~~~~~
@@ -170,7 +166,7 @@ library Secp256k1 {
             revert("SecretKeyInvalid()");
         }
 
-        // Use vm to compute pubKey = [sk]G.
+        // Use vm to compute pk = [sk]G.
         Vm.Wallet memory wallet = vm.createWallet(sk.asUint());
         return PublicKey(wallet.publicKeyX, wallet.publicKeyY);
     }
@@ -239,7 +235,7 @@ library Secp256k1 {
         return pk.intoPoint().yParity();
     }
 
-    /// @dev Mutates public key `pk` to Affine point.
+    /// @dev Mutates public key `pk` to affine point.
     function intoPoint(PublicKey memory pk)
         internal
         pure
@@ -247,12 +243,12 @@ library Secp256k1 {
     {
         Point memory point;
         assembly ("memory-safe") {
-            point := pubKey
+            point := pk
         }
         return point;
     }
 
-    /// @dev Mutates Affine point `point` to Public Key.
+    /// @dev Mutates affine point `point` to a public key.
     function intoPublicKey(Point memory point)
         internal
         pure
@@ -265,13 +261,13 @@ library Secp256k1 {
         return pk;
     }
 
-    /// @dev Returns public key `pk` as Projective Point.
+    /// @dev Returns public key `pk` as projective point.
     function toProjectivePoint(PublicKey memory pk)
         internal
         pure
         returns (ProjectivePoint memory)
     {
-        return pk.toPoint().toProjectivePoint();
+        return pk.intoPoint().toProjectivePoint();
     }
 
     //--------------------------------------------------------------------------

--- a/src/curves/Secp256k1.sol
+++ b/src/curves/Secp256k1.sol
@@ -8,6 +8,22 @@
 
 */
 
+// TODO:
+//  - [X] Rename JacobianPoint to ProjectivePoint
+//  - [X] Rename PointAtInfinity to Identity?
+//      - Maybe both? Basically type alias?
+//  - [ ] Complete addition formula from Renes-Costello-Batina 2015?
+//      - See https://eprint.iacr.org/2015/1060 Algorithm 7 + 8
+//      - For double Algorithm 9
+//
+//  - [X] Differentitate between bytes and serialization!
+//      - Serialization:
+//          - toEncodedPoint() -> SEC1 encoded ("normal")
+//          - toCompressedEncodedPoint() -> compressed SEC1 encoded
+//      - TODO: Note that identity case not implemented!!!!
+//
+//  - [X] Use SecretKey instead of PrivateKey?
+
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
@@ -16,48 +32,51 @@ import {Vm} from "forge-std/Vm.sol";
 import {
     Secp256k1Arithmetic,
     Point,
-    JacobianPoint
+    ProjectivePoint
 } from "./Secp256k1Arithmetic.sol";
 
 import {Random} from "../Random.sol";
 
 /**
- * @notice PrivateKey is a secret scalar
+ * @notice Secret key is an secp256k1 secret key
  *
- * @dev Note that a private key MUST be a field element,
- *      ie private key ∊ [1, Q).
+ * @dev Note that a secret key MUST be a field element, ie sk ∊ [1, Q).
  *
- * @dev Note that a private key MUST be created cryptographically secure!
- *      Generally, this means via randomness sourced from an CSPRNG.
+ * @dev Note that a secret key MUST be created cryptographically sound.
+ *      Generally, this means via randomness sources from an CSPRNG.
  *
- * @custom:example Generating a secure private key:
+ * @custom:example Securly generating a random secret key:
  *
  *      ```solidity
- *      import {Secp256k1, PrivateKey} from "crysol/curves/Secp256k1.sol";
- *      using Secp256k1 for PrivateKey;
+ *      import {Secp256k1, SecretKey} from "crysol/curves/Secp256k1.sol";
+ *      contract Example {
+ *          using Secp256k1 for SecretKey;
  *
- *      PrivateKey privKey = Secp256k1.newPrivateKey();
- *      assert(privKey.isValid());
- *      ```
+ *          SecretKey sk = Secp256k1.newSecretKey();
+ *          assert(sk.isValid());
+ *      }
+ *      ````
  */
-type PrivateKey is uint;
+type SecretKey is uint;
 
 /**
- * @notice PublicKey is a private key's public identifier
+ * @notice PublicKey is a secret key's public identifier
  *
- * @dev A public key is a point on the secp256k1 curve computed via [privKey]G.
+ * @dev A public key is a point on the secp256k1 curve computed via [sk]G.
  *
- * @custom:example Deriving a public key from a private key:
+ * @custom:example Deriving a public key from a secret key:
  *
  *      ```solidity
- *      import {Secp256k1, PrivateKey, PublicKey} from "crysol/curves/Secp256k1.sol";
- *      using Secp256k1 for PrivateKey;
- *      using Secp256k1 for PublicKey;
+ *      import {Secp256k1, SecretKey, PublicKey} from "crysol/curves/Secp256k1.sol";
+ *      contract Example {
+ *          using Secp256k1 for SecretKey;
+ *          using Secp256k1 for PublicKey;
  *
- *      PrivateKey privKey = Secp256k1.newPrivateKey();
+ *          SecretKey sk = Secp256k1.newSecretKey();
  *
- *      PublicKey memory pubKey = privKey.toPublicKey();
- *      assert(pubKey.isValid());
+ *          PublicKey memory pubKey = sk.toPublicKey();
+ *          assert(pubKey.isValid());
+ *      }
  *      ```
  */
 struct PublicKey {
@@ -75,7 +94,7 @@ struct PublicKey {
  * @author Inspired by Chronicle Protocol's Scribe (https://github.com/chronicleprotocol/scribe)
  */
 library Secp256k1 {
-    using Secp256k1 for PrivateKey;
+    using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
     using Secp256k1 for Point;
     using Secp256k1Arithmetic for Point;
@@ -112,84 +131,79 @@ library Secp256k1 {
     uint internal constant Q = Secp256k1Arithmetic.Q;
 
     //--------------------------------------------------------------------------
-    // Private Key
+    // Secret Key
 
-    /// @dev Returns a new cryptographically secure private key.
+    /// @dev Returns a new cryptographically secure secret key.
     ///
     /// @custom:vm Random::readUint()(uint)
-    function newPrivateKey() internal vmed returns (PrivateKey) {
+    function newSecretKey() internal vmed returns (SecretKey) {
         uint scalar;
         while (scalar == 0 || scalar >= Q) {
             // Note to not introduce potential bias via bounding operation.
             scalar = Random.readUint();
         }
-        return privateKeyFromUint(scalar);
+        return secretKeyFromUint(scalar);
     }
 
-    /// @dev Returns whether private key `privKey` is valid.
+    /// @dev Returns whether secret key `sk` is valid.
     ///
-    /// @dev A valid secp256k1 private key ∊ [1, Q).
-    function isValid(PrivateKey privKey) internal pure returns (bool) {
-        return privKey.asUint() != 0 && privKey.asUint() < Q;
+    /// @dev Note that a secret key MUST be a secp256k1 field element in order
+    ///      to be valid, ie sk ∊ [1, Q).
+    function isValid(SecretKey sk) internal pure returns (bool) {
+        uint scalar = sk.asUint();
+
+        return scalar != 0 && scalar < Q;
     }
 
-    /// @dev Returns the public key of private key `privKey`.
+    /// @dev Returns the public key of secret key `sk`.
     ///
     /// @dev Reverts if:
-    ///      - Private key invalid
+    ///      - Secret key invalid
     ///
     /// @custom:vm vm.createWallet(uint)
-    function toPublicKey(PrivateKey privKey)
+    function toPublicKey(SecretKey sk)
         internal
         vmed
         returns (PublicKey memory)
     {
-        if (!privKey.isValid()) {
-            revert("PrivateKeyInvalid()");
+        if (!sk.isValid()) {
+            revert("SecretKeyInvalid()");
         }
 
-        // Compute pubKey = [privKey]G via vm.
-        Vm.Wallet memory wallet = vm.createWallet(privKey.asUint());
+        // Use vm to compute pubKey = [sk]G.
+        Vm.Wallet memory wallet = vm.createWallet(sk.asUint());
         return PublicKey(wallet.publicKeyX, wallet.publicKeyY);
     }
 
-    /// @dev Returns uint `scalar` as private key.
+    /// @dev Returns uint `scalar` as secret key.
     ///
     /// @dev Reverts if:
     ///      - Scalar not in [1, Q)
-    function privateKeyFromUint(uint scalar)
-        internal
-        pure
-        returns (PrivateKey)
-    {
+    function secretKeyFromUint(uint scalar) internal pure returns (SecretKey) {
         if (scalar == 0 || scalar >= Q) {
             revert("InvalidScalar()");
         }
 
-        return PrivateKey.wrap(scalar);
+        return SecretKey.wrap(scalar);
     }
 
-    /// @dev Returns private key `privKey` as uint.
-    function asUint(PrivateKey privKey) internal pure returns (uint) {
-        return PrivateKey.unwrap(privKey);
+    /// @dev Returns secret key `sk` as uint.
+    function asUint(SecretKey sk) internal pure returns (uint) {
+        return SecretKey.unwrap(sk);
     }
 
     //--------------------------------------------------------------------------
     // Public Key
 
-    /// @dev Returns the address of public key `pubKey`.
+    /// @dev Returns the address of public key `pk`.
     ///
     /// @dev An Ethereum address is defined as the rightmost 160 bits of the
     ///      keccak256 hash of the concatenation of the hex-encoded x and y
     ///      coordinates of the corresponding ECDSA public key.
     ///
     ///      See "Appendix F: Signing Transactions" §134 in the Yellow Paper.
-    function toAddress(PublicKey memory pubKey)
-        internal
-        pure
-        returns (address)
-    {
-        bytes32 digest = pubKey.toHash();
+    function toAddress(PublicKey memory pk) internal pure returns (address) {
+        bytes32 digest = pk.toHash();
 
         address addr;
         assembly ("memory-safe") {
@@ -198,32 +212,35 @@ library Secp256k1 {
         return addr;
     }
 
-    /// @dev Returns the keccak256 hash of public key `pubKey`.
-    function toHash(PublicKey memory pubKey) internal pure returns (bytes32) {
+    /// @dev Returns the keccak256 hash of public key `pk`.
+    function toHash(PublicKey memory pk) internal pure returns (bytes32) {
         bytes32 digest;
         assembly ("memory-safe") {
-            digest := keccak256(pubKey, 0x40)
+            digest := keccak256(pk, 0x40)
         }
         return digest;
     }
 
-    /// @dev Returns whether public key `pubKey` is a valid secp256k1 public key.
-    function isValid(PublicKey memory pubKey) internal pure returns (bool) {
-        return pubKey.intoPoint().isOnCurve();
+    /// @dev Returns whether public key `pk` is a valid secp256k1 public key.
+    ///
+    /// @dev Note that a public key is valid if its either on the curve or the
+    ///      identity (aka point at infinity) point.
+    function isValid(PublicKey memory pk) internal pure returns (bool) {
+        return pk.intoPoint().isOnCurve();
     }
 
-    /// @dev Returns the y parity of public key `pubKey`.
+    /// @dev Returns the y parity of public key `pk`.
     ///
     /// @dev The value 0 represents an even y value and 1 represents an odd y
     ///      value.
     ///
     ///      See "Appendix F: Signing Transactions" in the Yellow Paper.
-    function yParity(PublicKey memory pubKey) internal pure returns (uint) {
-        return pubKey.intoPoint().yParity();
+    function yParity(PublicKey memory pk) internal pure returns (uint) {
+        return pk.intoPoint().yParity();
     }
 
-    /// @dev Mutates public key `pubKey` to Affine point.
-    function intoPoint(PublicKey memory pubKey)
+    /// @dev Mutates public key `pk` to Affine point.
+    function intoPoint(PublicKey memory pk)
         internal
         pure
         returns (Point memory)
@@ -241,37 +258,37 @@ library Secp256k1 {
         pure
         returns (PublicKey memory)
     {
-        PublicKey memory pubKey;
+        PublicKey memory pk;
         assembly ("memory-safe") {
-            pubKey := point
+            pk := point
         }
-        return pubKey;
+        return pk;
     }
 
-    /// @dev Returns public key `pubKey` as Jacobian Point.
-    function toJacobianPoint(PublicKey memory pubKey)
+    /// @dev Returns public key `pk` as Projective Point.
+    function toProjectivePoint(PublicKey memory pk)
         internal
         pure
-        returns (JacobianPoint memory)
+        returns (ProjectivePoint memory)
     {
-        return JacobianPoint(pubKey.x, pubKey.y, 1);
+        return pk.toPoint().toProjectivePoint();
     }
 
     //--------------------------------------------------------------------------
     // (De)Serialization
 
     //----------------------------------
-    // Private Key
+    // Secret Key
 
-    /// @dev Returns bytes `blob` as private key.
+    /// @dev Returns bytes `blob` as secret key.
     ///
     /// @dev Reverts if:
     ///      - Length not 32 bytes
     ///      - Deserialized scalar not in [1, Q)
-    function privateKeyFromBytes(bytes memory blob)
+    function secretKeyFromBytes(bytes memory blob)
         internal
         pure
-        returns (PrivateKey)
+        returns (SecretKey)
     {
         if (blob.length != 32) {
             revert("InvalidLength()");
@@ -282,27 +299,29 @@ library Secp256k1 {
             scalar := mload(add(blob, 0x20))
         }
 
-        return privateKeyFromUint(scalar);
+        return secretKeyFromUint(scalar);
     }
 
-    /// @dev Returns private key `privKey` as bytes.
-    function toBytes(PrivateKey privKey) internal pure returns (bytes memory) {
-        return abi.encodePacked(privKey.asUint());
+    /// @dev Returns secret key `sk` as bytes.
+    function toBytes(SecretKey sk) internal pure returns (bytes memory) {
+        return abi.encodePacked(sk.asUint());
     }
 
     //----------------------------------
     // Public Key
 
-    /// @dev Returns public key from bytes `blob`.
+    // TODO: Not totally correct. Identity case is missing!
+    //       See https://www.secg.org/sec1-v2.pdf page 10.
+    /// @dev Decodes public key from SEC1 encoded bytes blob `blob`.
     ///
     /// @dev Reverts if:
     ///      - Length not 65 bytes
     ///      - Prefix byte not 0x04
-    ///      - Deserialized public key invalid
+    ///      - Decoded public key invalid
     ///
     /// @dev Expects uncompressed 65 bytes encoding:
     ///         [0x04 prefix][32 bytes x coordinate][32 bytes y coordinate]
-    function publicKeyFromBytes(bytes memory blob)
+    function publicKeyFromEncoded(bytes memory blob)
         internal
         pure
         returns (PublicKey memory)
@@ -323,7 +342,7 @@ library Secp256k1 {
             revert("InvalidPrefix()");
         }
 
-        // Read x and y coordinates of public key.
+        // Read x and y coordinates.
         uint x;
         uint y;
         assembly ("memory-safe") {
@@ -332,25 +351,76 @@ library Secp256k1 {
         }
 
         // Make public key.
-        PublicKey memory pubKey = PublicKey(x, y);
+        PublicKey memory pk = PublicKey(x, y);
 
         // Revert if public key invalid.
-        if (!pubKey.isValid()) {
+        if (!pk.isValid()) {
             revert("InvalidPublicKey()");
         }
 
-        return pubKey;
+        return pk;
     }
 
-    /// @dev Returns public key `pubKey` as bytes.
+    // TODO: Not totally correct. Identity case is missing!
+    //       See https://www.secg.org/sec1-v2.pdf page 10.
+    /// @dev Encodes public key `pk` as SEC1 encoded bytes.
     ///
     /// @dev Provides uncompressed 65 bytes encoding:
     ///         [0x04 prefix][32 bytes x coordinate][32 bytes y coordinate]
-    function toBytes(PublicKey memory pubKey)
+    function toEncoded(PublicKey memory pk)
+        internal
+        pure
+        returns (bytes memory blob)
+    {
+        return abi.encodePacked(bytes1(0x04), pk.x, pk.y);
+    }
+
+    /// @dev Decodes public key from ABI-encoded bytes `blob`.
+    ///
+    /// @dev Reverts if:
+    ///      - Length not 64 bytes
+    ///      - Decoded public key invalid
+    ///
+    /// @dev Expects 64 bytes encoding:
+    ///         [32 bytes x coordinate][32 bytes y coordinate]
+    function publicKeyFromBytes(bytes memory blob)
+        internal
+        pure
+        returns (PublicKey memory)
+    {
+        // Revert if length not 65.
+        if (blob.length != 64) {
+            revert("InvalidLength()");
+        }
+
+        // Read x and y coordinates of public key.
+        uint x;
+        uint y;
+        assembly ("memory-safe") {
+            x := mload(add(blob, 0x20))
+            y := mload(add(blob, 0x40))
+        }
+
+        // Make public key.
+        PublicKey memory pk = PublicKey(x, y);
+
+        // Revert if public key invalid.
+        if (!pk.isValid()) {
+            revert("InvalidPublicKey()");
+        }
+
+        return pk;
+    }
+
+    /// @dev Encodes public key `pk` as ABI-encoded bytes.
+    ///
+    /// @dev Provides 64 bytes encoding:
+    ///         [32 bytes x coordinate][32 bytes y coordinate]
+    function toBytes(PublicKey memory pk)
         internal
         pure
         returns (bytes memory)
     {
-        return abi.encodePacked(bytes1(0x04), pubKey.x, pubKey.y);
+        return abi.encodePacked(pk.x, pk.y);
     }
 }

--- a/src/signatures/ECDSA.sol
+++ b/src/signatures/ECDSA.sol
@@ -60,13 +60,13 @@ struct Signature {
  * @author crysol (https://github.com/pmerkleplant/crysol)
  */
 library ECDSA {
+    using Secp256k1 for SecretKey;
+    using Secp256k1 for PublicKey;
+
     using ECDSA for address;
     using ECDSA for Signature;
     using ECDSA for SecretKey;
     using ECDSA for PublicKey;
-
-    using Secp256k1 for SecretKey;
-    using Secp256k1 for PublicKey;
 
     // ~~~~~~~ Prelude ~~~~~~~
     // forgefmt: disable-start
@@ -226,7 +226,7 @@ library ECDSA {
         uint8 v;
         bytes32 r;
         bytes32 s;
-        (v, r, s) = vm.sign(pk.asUint(), digest);
+        (v, r, s) = vm.sign(sk.asUint(), digest);
 
         Signature memory sig = Signature(v, r, s);
         assert(!sig.isMalleable());

--- a/src/signatures/Schnorr.sol
+++ b/src/signatures/Schnorr.sol
@@ -41,15 +41,15 @@ struct Signature {
  * @author Inspired by Chronicle Protocol's Scribe (https://github.com/chronicleprotocol/scribe)
  */
 library Schnorr {
-    using Schnorr for address;
-    using Schnorr for Signature;
-    using Schnorr for SecretKey;
-    using Schnorr for PublicKey;
-
     using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
 
     using Nonce for SecretKey;
+
+    using Schnorr for address;
+    using Schnorr for Signature;
+    using Schnorr for SecretKey;
+    using Schnorr for PublicKey;
 
     // ~~~~~~~ Prelude ~~~~~~~
     // forgefmt: disable-start

--- a/src/signatures/Schnorr.sol
+++ b/src/signatures/Schnorr.sol
@@ -15,7 +15,7 @@ import {Vm} from "forge-std/Vm.sol";
 
 import {Message} from "../Message.sol";
 
-import {Secp256k1, PrivateKey, PublicKey} from "../curves/Secp256k1.sol";
+import {Secp256k1, SecretKey, PublicKey} from "../curves/Secp256k1.sol";
 
 import {Nonce} from "./utils/Nonce.sol";
 
@@ -43,13 +43,13 @@ struct Signature {
 library Schnorr {
     using Schnorr for address;
     using Schnorr for Signature;
-    using Schnorr for PrivateKey;
+    using Schnorr for SecretKey;
     using Schnorr for PublicKey;
 
-    using Secp256k1 for PrivateKey;
+    using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
 
-    using Nonce for PrivateKey;
+    using Nonce for SecretKey;
 
     // ~~~~~~~ Prelude ~~~~~~~
     // forgefmt: disable-start
@@ -64,36 +64,36 @@ library Schnorr {
     //--------------------------------------------------------------------------
     // Signature Verification
 
-    /// @dev Returns whether public key `pubKey` signs via Schnorr signature
-    ///      `sig` hash digest `digest`.
+    /// @dev Returns whether public key `pk` signs via Schnorr signature `sig`
+    ///      hash digest `digest`.
     ///
     /// @dev Reverts if:
     ///      - Public key invalid
     ///      - Schnorr signature malleable
     ///      - Schnorr signature trivial
     function verify(
-        PublicKey memory pubKey,
+        PublicKey memory pk,
         bytes memory message,
         Signature memory sig
     ) internal pure returns (bool) {
         bytes32 digest = keccak256(message);
 
-        return pubKey.verify(digest, sig);
+        return pk.verify(digest, sig);
     }
 
-    /// @dev Returns whether public key `pubKey` signs via Schnorr signature
-    ///      `sig` hash digest `digest`.
+    /// @dev Returns whether public key `pk` signs via Schnorr signature `sig`
+    ///      hash digest `digest`.
     ///
     /// @dev Reverts if:
     ///      - Public key invalid
-    ///      - Schnorr signature malleable
     ///      - Schnorr signature trivial
-    function verify(
-        PublicKey memory pubKey,
-        bytes32 digest,
-        Signature memory sig
-    ) internal pure returns (bool) {
-        if (!pubKey.isValid()) {
+    ///      - Schnorr signature malleable
+    function verify(PublicKey memory pk, bytes32 digest, Signature memory sig)
+        internal
+        pure
+        returns (bool)
+    {
+        if (!pk.isValid()) {
             revert("PublicKeyInvalid()");
         }
 
@@ -105,17 +105,17 @@ library Schnorr {
             revert("SignatureMalleable()");
         }
 
-        // Construct challenge = H(Pₓ ‖ Pₚ ‖ m ‖ Rₑ) (mod Q)
+        // Construct challenge = H(Pkₓ ‖ Pkₚ ‖ m ‖ Rₑ) (mod Q)
         uint challenge = uint(
             keccak256(
                 abi.encodePacked(
-                    pubKey.x, uint8(pubKey.yParity()), digest, sig.commitment
+                    pk.x, uint8(pk.yParity()), digest, sig.commitment
                 )
             )
         ) % Secp256k1.Q;
 
-        // Compute ecrecover_msgHash = -sig * Pₓ      (mod Q)
-        //                           = Q - (sig * Pₓ) (mod Q)
+        // Compute ecrecover_msgHash = -sig * Pkₓ      (mod Q)
+        //                           = Q - (sig * Pkₓ) (mod Q)
         //
         // Unchecked because the only protected operation performed is the
         // subtraction from Q where the subtrahend is the result of a (mod Q)
@@ -123,23 +123,23 @@ library Schnorr {
         bytes32 ecrecover_msgHash;
         unchecked {
             ecrecover_msgHash = bytes32(
-                Secp256k1.Q - mulmod(uint(sig.signature), pubKey.x, Secp256k1.Q)
+                Secp256k1.Q - mulmod(uint(sig.signature), pk.x, Secp256k1.Q)
             );
         }
 
-        // Compute ecrecover_v = Pₚ + 27
+        // Compute ecrecover_v = Pkₚ + 27
         //
-        // Unchecked because pubKey.yParity() ∊ {0, 1} which cannot overflow
-        // by adding 27.
+        // Unchecked because pk.yParity() ∊ {0, 1} which cannot overflow by
+        // adding 27.
         uint8 ecrecover_v;
         unchecked {
-            ecrecover_v = uint8(pubKey.yParity() + 27);
+            ecrecover_v = uint8(pk.yParity() + 27);
         }
 
-        // Set ecrecover_r = Pₓ
-        bytes32 ecrecover_r = bytes32(pubKey.x);
+        // Set ecrecover_r = Pkₓ
+        bytes32 ecrecover_r = bytes32(pk.x);
 
-        // Compute ecrecover_s = Q - (e * Pₓ) (mod Q)
+        // Compute ecrecover_s = Q - (e * Pkₓ) (mod Q)
         //
         // Unchecked because the only protected operation performed is the
         // subtraction from Q where the subtrahend is the result of a (mod Q)
@@ -147,10 +147,10 @@ library Schnorr {
         bytes32 ecrecover_s;
         unchecked {
             ecrecover_s =
-                bytes32(Secp256k1.Q - mulmod(challenge, pubKey.x, Secp256k1.Q));
+                bytes32(Secp256k1.Q - mulmod(challenge, pk.x, Secp256k1.Q));
         }
 
-        // Compute ([sig]G - [e]P)ₑ via ecrecover.
+        // Compute ([sig]G - [e]Pk)ₑ via ecrecover.
         // forgefmt: disable-next-item
         address recovered = ecrecover(
             ecrecover_msgHash,
@@ -159,7 +159,7 @@ library Schnorr {
             ecrecover_s
         );
 
-        // Verification succeeds iff ([sig]G - [e]P)ₑ = Rₑ.
+        // Verification succeeds iff ([sig]G - [e]Pk)ₑ = Rₑ.
         //
         // Note that commitment is guaranteed to not be zero.
         return sig.commitment == recovered;
@@ -168,64 +168,64 @@ library Schnorr {
     //--------------------------------------------------------------------------
     // Signature Creation
 
-    /// @dev Returns a Schnorr signature signed by private key `privKey` signing
+    /// @dev Returns a Schnorr signature signed by secret key `sk` signing
     ///      message `message`.
     ///
     /// @dev Reverts if:
-    ///      - Private key invalid
+    ///      - Secret key invalid
     ///
-    /// @custom:vm sign(PrivateKey, bytes32)
-    function sign(PrivateKey privKey, bytes memory message)
+    /// @custom:vm sign(SecretKey, bytes32)
+    function sign(SecretKey sk, bytes memory message)
         internal
         vmed
         returns (Signature memory)
     {
         bytes32 digest = keccak256(message);
 
-        return privKey.sign(digest);
+        return sk.sign(digest);
     }
 
-    /// @dev Returns a Schnorr signature signed by private key `privKey` signing
+    /// @dev Returns a Schnorr signature signed by secret key `sk` signing
     ///      hash digest `digest`.
     ///
     /// @dev Reverts if:
-    ///      - Private key invalid
+    ///      - Secret key invalid
     ///
-    /// @custom:vm curves/Secp256k1::toPublicKey(PrivateKey)(PublicKey)
-    function sign(PrivateKey privKey, bytes32 digest)
+    /// @custom:vm curves/Secp256k1::toPublicKey(SecretKey)(PublicKey)
+    function sign(SecretKey sk, bytes32 digest)
         internal
         vmed
         returns (Signature memory)
     {
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
 
         // Derive deterministic nonce ∊ [1, Q).
-        uint nonce = privKey.deriveNonce(digest) % Secp256k1.Q;
-        // assert(nonce != 0); // TODO: Revisit once nonce derived via RFC 6979.
+        uint nonce = sk.deriveNonce(digest) % Secp256k1.Q;
+        assert(nonce != 0); // TODO: Revisit once nonce derived via RFC 6979.
 
         // Compute nonce's public key.
-        PublicKey memory noncePubKey =
-            Secp256k1.privateKeyFromUint(nonce).toPublicKey();
+        PublicKey memory noncePk =
+            Secp256k1.secretKeyFromUint(nonce).toPublicKey();
 
         // Derive commitment from nonce's public key.
-        address commitment = noncePubKey.toAddress();
+        address commitment = noncePk.toAddress();
 
-        // Construct challenge = H(Pₓ ‖ Pₚ ‖ m ‖ Rₑ) (mod Q)
+        // Construct challenge = H(Pkₓ ‖ Pkₚ ‖ m ‖ Rₑ) (mod Q)
         bytes32 challenge = bytes32(
             uint(
                 keccak256(
                     abi.encodePacked(
-                        pubKey.x, uint8(pubKey.yParity()), digest, commitment
+                        pk.x, uint8(pk.yParity()), digest, commitment
                     )
                 )
             ) % Secp256k1.Q
         );
 
-        // Compute signature = k + (e * x) (mod Q)
+        // Compute signature = k + (e * sk) (mod Q)
         bytes32 signature = bytes32(
             addmod(
                 nonce,
-                mulmod(uint(challenge), privKey.asUint(), Secp256k1.Q),
+                mulmod(uint(challenge), sk.asUint(), Secp256k1.Q),
                 Secp256k1.Q
             )
         );
@@ -233,41 +233,42 @@ library Schnorr {
         return Signature(signature, commitment);
     }
 
-    /// @dev Returns a Schnorr signature signed by private key `privKey` singing
+    /// @dev Returns a Schnorr signature signed by secret key `sk` singing
     ///      message `message`'s keccak256 digest as Ethereum Signed Message.
     ///
     /// @dev For more info regarding Ethereum Signed Messages, see {Message.sol}.
     ///
     /// @dev Reverts if:
-    ///      - Private key invalid
+    ///      - Secret key invalid
     ///
-    /// @custom:vm sign(PrivateKey, bytes32)
-    function signEthereumSignedMessageHash(
-        PrivateKey privKey,
-        bytes memory message
-    ) internal vmed returns (Signature memory) {
+    /// @custom:vm sign(SecretKey, bytes32)
+    function signEthereumSignedMessageHash(SecretKey sk, bytes memory message)
+        internal
+        vmed
+        returns (Signature memory)
+    {
         bytes32 digest = Message.deriveEthereumSignedMessageHash(message);
 
-        return privKey.sign(digest);
+        return sk.sign(digest);
     }
 
-    /// @dev Returns a Schnorr signature signed by private key `privKey` singing
+    /// @dev Returns a Schnorr signature signed by secret key `sk` singing
     ///      hash digest `digest` as Ethereum Signed Message.
     ///
     /// @dev For more info regarding Ethereum Signed Messages, see {Message.sol}.
     ///
     /// @dev Reverts if:
-    ///      - Private key invalid
+    ///      - Secret key invalid
     ///
-    /// @custom:vm sign(PrivateKey, bytes32)
-    function signEthereumSignedMessageHash(PrivateKey privKey, bytes32 digest)
+    /// @custom:vm sign(SecretKey, bytes32)
+    function signEthereumSignedMessageHash(SecretKey sk, bytes32 digest)
         internal
         vmed
         returns (Signature memory)
     {
         bytes32 digest2 = Message.deriveEthereumSignedMessageHash(digest);
 
-        return privKey.sign(digest2);
+        return sk.sign(digest2);
     }
 
     //--------------------------------------------------------------------------

--- a/src/signatures/utils/Nonce.sol
+++ b/src/signatures/utils/Nonce.sol
@@ -11,9 +11,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
-import {Secp256k1, PrivateKey} from "../../curves/Secp256k1.sol";
+import {Secp256k1, SecretKey} from "../../curves/Secp256k1.sol";
 
-// TODO: Library to derive deterministic nonces following RFC 6979.
+// TODO: Goal: Library to derive deterministic nonces following RFC 6979.
 //
 //       For Rust implementation (used by foundry), see:
 //       - https://github.com/RustCrypto/signatures/blob/master/rfc6979/src/lib.rs#L77
@@ -29,40 +29,38 @@ import {Secp256k1, PrivateKey} from "../../curves/Secp256k1.sol";
  * @author crysol (https://github.com/pmerkleplant/crysol)
  */
 library Nonce {
-    using Nonce for PrivateKey;
+    using Nonce for SecretKey;
     using Secp256k1 for PrivateKey;
 
-    /// @dev Derives a deterministic nonce from private key `privKey` and message
+    /// @dev Derives a deterministic nonce from secret key `sk` and message
     ///      `message`.
     ///
     /// @dev Note that a nonce is of type uint and not bounded by any field!
     ///
     /// @custom:invariant Keccak256 image is never zero
-    ///     ∀ (privKey, msg) ∊ (PrivateKey, bytes):
-    ///         keccak256(privKey ‖ keccak256(message)) != 0
-    function deriveNonce(PrivateKey privKey, bytes memory message)
+    ///     ∀ (sk, msg) ∊ (SecretKey, bytes): keccak256(sk ‖ keccak256(message)) != 0
+    function deriveNonce(SecretKey sk, bytes memory message)
         internal
         pure
         returns (uint)
     {
         bytes32 digest = keccak256(message);
 
-        return privKey.deriveNonce(digest);
+        return sk.deriveNonce(digest);
     }
 
-    /// @dev Derives a deterministic nonce from private key `privKey` and message
+    /// @dev Derives a deterministic nonce from secret key `sk` and message
     ///      `message`.
     ///
     /// @dev Note that a nonce is of type uint and not bounded by any field!
     ///
     /// @custom:invariant Keccak256 image is never zero
-    ///     ∀ (privKey, digest) ∊ (PrivateKey, bytes32):
-    ///         keccak256(privKey ‖ digest) != 0
+    ///     ∀ (sk, digest) ∊ (SecretKey, bytes32): keccak256(sk ‖ digest) != 0
     function deriveNonce(PrivateKey privKey, bytes32 digest)
         internal
         pure
         returns (uint)
     {
-        return uint(keccak256(abi.encodePacked(privKey.asUint(), digest)));
+        return uint(keccak256(abi.encodePacked(sk.asUint(), digest)));
     }
 }

--- a/src/signatures/utils/Nonce.sol
+++ b/src/signatures/utils/Nonce.sol
@@ -29,8 +29,9 @@ import {Secp256k1, SecretKey} from "../../curves/Secp256k1.sol";
  * @author crysol (https://github.com/pmerkleplant/crysol)
  */
 library Nonce {
+    using Secp256k1 for SecretKey;
+
     using Nonce for SecretKey;
-    using Secp256k1 for PrivateKey;
 
     /// @dev Derives a deterministic nonce from secret key `sk` and message
     ///      `message`.
@@ -56,7 +57,7 @@ library Nonce {
     ///
     /// @custom:invariant Keccak256 image is never zero
     ///     ∀ (sk, digest) ∊ (SecretKey, bytes32): keccak256(sk ‖ digest) != 0
-    function deriveNonce(PrivateKey privKey, bytes32 digest)
+    function deriveNonce(SecretKey sk, bytes32 digest)
         internal
         pure
         returns (uint)

--- a/test/Prelude.t.sol
+++ b/test/Prelude.t.sol
@@ -21,6 +21,8 @@ contract PreludeTest is Test {
     // forgefmt: disable-end
     // ~~~~~~~~~~~~~~~~~~~~~~~
 
+    function vmedFunction() internal vmed {}
+
     function test_vmed() public {
         vmedFunction();
     }
@@ -36,6 +38,4 @@ contract PreludeTest is Test {
             vmedFunction();
         } catch {}
     }
-
-    function vmedFunction() internal vmed {}
 }

--- a/test/curves/secp256k1/Secp256k1.t.sol
+++ b/test/curves/secp256k1/Secp256k1.t.sol
@@ -183,9 +183,7 @@ contract Secp256k1Test is Test {
         assertEq(pk.y, point.y);
     }
 
-    function testFuzz_PublicKey_toProjectivePoint(PublicKey memory pk)
-        public
-    {
+    function testFuzz_PublicKey_toProjectivePoint(PublicKey memory pk) public {
         ProjectivePoint memory jPoint = wrapper.toProjectivePoint(pk);
 
         assertEq(jPoint.x, pk.x);
@@ -196,7 +194,7 @@ contract Secp256k1Test is Test {
     //--------------------------------------------------------------------------
     // Test: (De)Serialization
 
-/*
+    /*
 
     //----------------------------------
     // Private Key
@@ -347,8 +345,7 @@ contract Secp256k1Test is Test {
     function test_PublicKey_asBytes_ViaGenerator() public {
         assertEq(GENERATOR_BYTES_UNCOMPRESSED, wrapper.toBytes(Secp256k1.G()));
     }
-*/
-
+    */
 }
 
 /**
@@ -381,10 +378,7 @@ contract Secp256k1Wrapper {
         return sk.isValid();
     }
 
-    function toPublicKey(SecretKey sk)
-        public
-        returns (PublicKey memory)
-    {
+    function toPublicKey(SecretKey sk) public returns (PublicKey memory) {
         return sk.toPublicKey();
     }
 
@@ -468,11 +462,7 @@ contract Secp256k1Wrapper {
         return Secp256k1.publicKeyFromBytes(blob);
     }
 
-    function toBytes(PublicKey memory pk)
-        public
-        pure
-        returns (bytes memory)
-    {
+    function toBytes(PublicKey memory pk) public pure returns (bytes memory) {
         return pk.toBytes();
     }
 }

--- a/test/curves/secp256k1/Secp256k1.t.sol
+++ b/test/curves/secp256k1/Secp256k1.t.sol
@@ -4,23 +4,24 @@ pragma solidity ^0.8.16;
 import {Test} from "forge-std/Test.sol";
 import {console2 as console} from "forge-std/console2.sol";
 
-import {Secp256k1, PrivateKey, PublicKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1, SecretKey, PublicKey} from "src/curves/Secp256k1.sol";
 import {
     Secp256k1Arithmetic,
     Point,
-    JacobianPoint
+    ProjectivePoint
 } from "src/curves/Secp256k1Arithmetic.sol";
 
 /**
  * @notice Secp256k1 Unit Tests
  */
 contract Secp256k1Test is Test {
-    using Secp256k1 for PrivateKey;
+    using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
+    using Secp256k1 for Point;
 
     // Uncompressed Generator G.
     // Copied from [Sec 2 v2].
-    bytes constant GENERATOR_BYTES_UNCOMPRESSED =
+    bytes constant GENERATOR_ENCODED_UNCOMPRESSED =
         hex"0479BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8";
 
     Secp256k1Wrapper wrapper;
@@ -35,66 +36,65 @@ contract Secp256k1Test is Test {
     function test_G() public {
         PublicKey memory got = wrapper.G();
         PublicKey memory want =
-            Secp256k1.publicKeyFromBytes(GENERATOR_BYTES_UNCOMPRESSED);
+            Secp256k1.publicKeyFromEncoded(GENERATOR_ENCODED_UNCOMPRESSED);
 
         assertEq(got.x, want.x);
         assertEq(got.y, want.y);
     }
 
     //--------------------------------------------------------------------------
-    // Test: Private Key
+    // Test: Secret Key
 
-    // -- newPrivateKey
+    // -- newSecretKey
 
-    function test_newPrivateKey() public {
-        PrivateKey privKey = wrapper.newPrivateKey();
+    function test_newSecretKey() public {
+        SecretKey sk = wrapper.newSecretKey();
 
-        assertTrue(privKey.isValid());
+        assertTrue(sk.isValid());
 
-        // Verify vm can create wallet from private key.
-        vm.createWallet(privKey.asUint());
+        // Verify vm can create wallet from secret key.
+        vm.createWallet(sk.asUint());
     }
 
     // -- isValid
 
-    function testFuzz_PrivateKey_isValid(uint seed) public {
-        uint privKey = _bound(seed, 1, Secp256k1.Q - 1);
+    function testFuzz_SecretKey_isValid(uint seed) public {
+        uint scalar = _bound(seed, 1, Secp256k1.Q - 1);
 
-        assertTrue(wrapper.isValid(PrivateKey.wrap(privKey)));
+        assertTrue(wrapper.isValid(SecretKey.wrap(scalar)));
     }
 
-    function test_PrivateKey_isValid_FailsIf_PrivateKeyIsZero() public {
-        assertFalse(wrapper.isValid(PrivateKey.wrap(0)));
+    function test_SecretKey_isValid_FailsIf_SecertKeyIsZero() public {
+        assertFalse(wrapper.isValid(SecretKey.wrap(0)));
     }
 
-    function testFuzz_PrivateKey_isValid_FailsIf_PrivateKeyGreaterOrEqualToQ(
+    function testFuzz_SecretKey_isValid_FailsIf_SecretKeyGreaterOrEqualToQ(
         uint seed
     ) public {
-        uint privKey = _bound(seed, Secp256k1.Q, type(uint).max);
+        uint scalar = _bound(seed, Secp256k1.Q, type(uint).max);
 
-        assertFalse(wrapper.isValid(PrivateKey.wrap(privKey)));
+        assertFalse(wrapper.isValid(SecretKey.wrap(scalar)));
     }
 
     // -- toPublicKey
 
-    function testFuzz_PrivateKey_toPublicKey(uint seed) public {
-        PrivateKey privKey =
-            Secp256k1.privateKeyFromUint(_bound(seed, 1, Secp256k1.Q - 1));
+    function testFuzz_SecretKey_toPublicKey(uint seed) public {
+        SecretKey sk =
+            Secp256k1.secretKeyFromUint(_bound(seed, 1, Secp256k1.Q - 1));
 
-        address got = wrapper.toPublicKey(privKey).toAddress();
-        address want = vm.addr(privKey.asUint());
+        address got = wrapper.toPublicKey(sk).toAddress();
+        address want = vm.addr(sk.asUint());
 
         assertEq(got, want);
     }
 
-    function testFuzz_PrivateKey_toPublicKey_RevertsIf_PrivateKeyInvalid(
+    function testFuzz_SecretKey_toPublicKey_RevertsIf_SecretKeyInvalid(
         uint seed
     ) public {
-        PrivateKey privKey =
-            PrivateKey.wrap(_bound(seed, Secp256k1.Q, type(uint).max));
+        SecretKey sk = SecretKey.wrap(_bound(seed, Secp256k1.Q, type(uint).max));
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.toPublicKey(privKey);
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.toPublicKey(sk);
     }
 
     //--------------------------------------------------------------------------
@@ -103,48 +103,55 @@ contract Secp256k1Test is Test {
     // -- toAddress
 
     function testFuzz_PublicKey_toAddress(uint seed) public {
-        PrivateKey privKey =
-            Secp256k1.privateKeyFromUint(_bound(seed, 1, Secp256k1.Q - 1));
+        SecretKey sk =
+            Secp256k1.secretKeyFromUint(_bound(seed, 1, Secp256k1.Q - 1));
 
-        assertEq(
-            wrapper.toAddress(Secp256k1.toPublicKey(privKey)),
-            vm.addr(privKey.asUint())
-        );
+        address got = wrapper.toAddress(Secp256k1.toPublicKey(sk));
+        address want = vm.addr(sk.asUint());
+
+        assertEq(got, want);
     }
 
     // -- toHash
 
-    function testFuzz_PublicKey_toHash(PublicKey memory pubKey) public {
-        bytes32 got = wrapper.toHash(pubKey);
-        bytes32 want = keccak256(abi.encodePacked(pubKey.x, pubKey.y));
+    function testFuzz_PublicKey_toHash(PublicKey memory pk) public {
+        bytes32 got = wrapper.toHash(pk);
+        bytes32 want = keccak256(abi.encodePacked(pk.x, pk.y));
 
         assertEq(got, want);
     }
 
     // -- isValid
 
-    function testFuzz_PublicKey_isValid(uint seed) public {
-        PrivateKey privKey =
-            Secp256k1.privateKeyFromUint(_bound(seed, 1, Secp256k1.Q - 1));
+    function testFuzz_PublicKey_isValid_If_CreatedViaValidSecretKey(uint seed)
+        public
+    {
+        SecretKey sk =
+            Secp256k1.secretKeyFromUint(_bound(seed, 1, Secp256k1.Q - 1));
 
-        // Every public key created via valid private key is valid.
-        assertTrue(wrapper.isValid(privKey.toPublicKey()));
+        // Every public key created via valid secret key is valid.
+        assertTrue(wrapper.isValid(sk.toPublicKey()));
+    }
+
+    function test_PublicKey_isValid_If_Identity() public {
+        PublicKey memory pk = Secp256k1Arithmetic.Identity().intoPublicKey();
+
+        assertTrue(pk.isValid());
     }
 
     function test_PublicKey_isValid_FailsIf_PointNotOnCurve() public {
-        PublicKey memory pubKey;
+        PublicKey memory pk;
 
-        pubKey.x = 0;
-        pubKey.y = 0;
-        assertFalse(wrapper.isValid(pubKey));
+        // Zero point not on curve.
+        pk.x = 0;
+        pk.y = 0;
+        assertFalse(wrapper.isValid(pk));
 
-        pubKey.x = 1;
-        pubKey.x = 3;
-        assertFalse(wrapper.isValid(pubKey));
-
-        pubKey.x = type(uint).max;
-        pubKey.x = type(uint).max;
-        assertFalse(wrapper.isValid(pubKey));
+        // Some other points.
+        pk.x = 1;
+        pk.x = 3;
+        assertFalse(wrapper.isValid(pk));
+        // TODO: Test PublicKey.isValid(): Add more points.
     }
 
     // -- yParity
@@ -162,32 +169,34 @@ contract Secp256k1Test is Test {
     // @todo Add no memory expansion tests for `into__()` functions.
     //       Must directly use library, not wrapper.
 
-    function testFuzz_PublicKey_intoPoint(PublicKey memory pubKey) public {
-        Point memory point = wrapper.intoPoint(pubKey);
+    function testFuzz_PublicKey_intoPoint(PublicKey memory pk) public {
+        Point memory point = wrapper.intoPoint(pk);
 
-        assertEq(point.x, pubKey.x);
-        assertEq(point.y, pubKey.y);
+        assertEq(point.x, pk.x);
+        assertEq(point.y, pk.y);
     }
 
     function testFuzz_Point_intoPublicKey(Point memory point) public {
-        PublicKey memory pubKey = wrapper.intoPublicKey(point);
+        PublicKey memory pk = wrapper.intoPublicKey(point);
 
-        assertEq(pubKey.x, point.x);
-        assertEq(pubKey.y, point.y);
+        assertEq(pk.x, point.x);
+        assertEq(pk.y, point.y);
     }
 
-    function testFuzz_PublicKey_toJacobianPoint(PublicKey memory pubKey)
+    function testFuzz_PublicKey_toProjectivePoint(PublicKey memory pk)
         public
     {
-        JacobianPoint memory jacPoint = wrapper.toJacobianPoint(pubKey);
+        ProjectivePoint memory jPoint = wrapper.toProjectivePoint(pk);
 
-        assertEq(jacPoint.x, pubKey.x);
-        assertEq(jacPoint.y, pubKey.y);
-        assertEq(jacPoint.z, 1);
+        assertEq(jPoint.x, pk.x);
+        assertEq(jPoint.y, pk.y);
+        assertEq(jPoint.z, 1);
     }
 
     //--------------------------------------------------------------------------
     // Test: (De)Serialization
+
+/*
 
     //----------------------------------
     // Private Key
@@ -338,6 +347,8 @@ contract Secp256k1Test is Test {
     function test_PublicKey_asBytes_ViaGenerator() public {
         assertEq(GENERATOR_BYTES_UNCOMPRESSED, wrapper.toBytes(Secp256k1.G()));
     }
+*/
+
 }
 
 /**
@@ -346,9 +357,10 @@ contract Secp256k1Test is Test {
  * @dev For more info, see https://github.com/foundry-rs/foundry/pull/3128#issuecomment-1241245086.
  */
 contract Secp256k1Wrapper {
-    using Secp256k1 for PrivateKey;
+    using Secp256k1 for SecretKey;
     using Secp256k1 for PublicKey;
     using Secp256k1 for Point;
+
     using Secp256k1Arithmetic for Point;
 
     //--------------------------------------------------------------------------
@@ -359,56 +371,56 @@ contract Secp256k1Wrapper {
     }
 
     //--------------------------------------------------------------------------
-    // Private Key
+    // Secret Key
 
-    function newPrivateKey() public returns (PrivateKey) {
-        return Secp256k1.newPrivateKey();
+    function newSecretKey() public returns (SecretKey) {
+        return Secp256k1.newSecretKey();
     }
 
-    function isValid(PrivateKey privKey) public pure returns (bool) {
-        return privKey.isValid();
+    function isValid(SecretKey sk) public pure returns (bool) {
+        return sk.isValid();
     }
 
-    function toPublicKey(PrivateKey privKey)
+    function toPublicKey(SecretKey sk)
         public
         returns (PublicKey memory)
     {
-        return privKey.toPublicKey();
+        return sk.toPublicKey();
     }
 
-    function privateKeyFromUint(uint scalar) public pure returns (PrivateKey) {
-        return Secp256k1.privateKeyFromUint(scalar);
+    function secretKeyFromUint(uint scalar) public pure returns (SecretKey) {
+        return Secp256k1.secretKeyFromUint(scalar);
     }
 
-    function asUint(PrivateKey privKey) public pure returns (uint) {
-        return privKey.asUint();
+    function asUint(SecretKey sk) public pure returns (uint) {
+        return sk.asUint();
     }
 
     //--------------------------------------------------------------------------
     // Public Key
 
-    function toAddress(PublicKey memory pubKey) public pure returns (address) {
-        return pubKey.toAddress();
+    function toAddress(PublicKey memory pk) public pure returns (address) {
+        return pk.toAddress();
     }
 
-    function toHash(PublicKey memory pubKey) public pure returns (bytes32) {
-        return pubKey.toHash();
+    function toHash(PublicKey memory pk) public pure returns (bytes32) {
+        return pk.toHash();
     }
 
-    function isValid(PublicKey memory pubKey) public pure returns (bool) {
-        return pubKey.isValid();
+    function isValid(PublicKey memory pk) public pure returns (bool) {
+        return pk.isValid();
     }
 
-    function yParity(PublicKey memory pubKey) public pure returns (uint) {
-        return pubKey.yParity();
+    function yParity(PublicKey memory pk) public pure returns (uint) {
+        return pk.yParity();
     }
 
-    function intoPoint(PublicKey memory pubKey)
+    function intoPoint(PublicKey memory pk)
         public
         pure
         returns (Point memory)
     {
-        return pubKey.intoPoint();
+        return pk.intoPoint();
     }
 
     function intoPublicKey(Point memory point)
@@ -419,30 +431,30 @@ contract Secp256k1Wrapper {
         return point.intoPublicKey();
     }
 
-    function toJacobianPoint(PublicKey memory pubKey)
+    function toProjectivePoint(PublicKey memory pk)
         public
         pure
-        returns (JacobianPoint memory)
+        returns (ProjectivePoint memory)
     {
-        return pubKey.toJacobianPoint();
+        return pk.toProjectivePoint();
     }
 
     //--------------------------------------------------------------------------
     // (De)Serialization
 
     //----------------------------------
-    // Private Key
+    // Secret Key
 
-    function privateKeyFromBytes(bytes memory blob)
+    function secretKeyFromBytes(bytes memory blob)
         public
         pure
-        returns (PrivateKey)
+        returns (SecretKey)
     {
-        return Secp256k1.privateKeyFromBytes(blob);
+        return Secp256k1.secretKeyFromBytes(blob);
     }
 
-    function toBytes(PrivateKey privKey) public pure returns (bytes memory) {
-        return privKey.toBytes();
+    function toBytes(SecretKey sk) public pure returns (bytes memory) {
+        return sk.toBytes();
     }
 
     //----------------------------------
@@ -456,11 +468,11 @@ contract Secp256k1Wrapper {
         return Secp256k1.publicKeyFromBytes(blob);
     }
 
-    function toBytes(PublicKey memory pubKey)
+    function toBytes(PublicKey memory pk)
         public
         pure
         returns (bytes memory)
     {
-        return pubKey.toBytes();
+        return pk.toBytes();
     }
 }

--- a/test/examples/curves/Secp256k1.t.sol
+++ b/test/examples/curves/Secp256k1.t.sol
@@ -8,7 +8,7 @@ import {Secp256k1Example} from "examples/curves/Secp256k1.sol";
 /**
  * @title Secp256k1ExamplesTest
  *
- * @notice Tests Secp256k1 examples in src/examples/.
+ * @notice Tests secp256k1 examples in examples/curves/Secp256kk1.sol.
  */
 contract Secp256k1ExamplesTest is Test {
     Secp256k1Example example;

--- a/test/examples/signatures/ECDSA.t.sol
+++ b/test/examples/signatures/ECDSA.t.sol
@@ -8,7 +8,7 @@ import {ECDSAExample} from "examples/signatures/ECDSA.sol";
 /**
  * @title ECDSAExamplesTest
  *
- * @notice Tests ECDSA examples in src/examples/.
+ * @notice Tests ECDSA examples in examples/signatures/ECDSA.sol.
  */
 contract ECDSAExamplesTest is Test {
     ECDSAExample example;

--- a/test/examples/signatures/Schnorr.t.sol
+++ b/test/examples/signatures/Schnorr.t.sol
@@ -8,7 +8,7 @@ import {SchnorrExample} from "examples/signatures/Schnorr.sol";
 /**
  * @title SchnorrExamplesTest
  *
- * @notice Tests Schnorr examples in src/examples/.
+ * @notice Tests Schnorr examples in examples/signatures/Schnorr.sol.
  */
 contract SchnorrExamplesTest is Test {
     SchnorrExample example;

--- a/test/signatures/ECDSA.t.sol
+++ b/test/signatures/ECDSA.t.sol
@@ -190,9 +190,7 @@ contract ECDSATest is Test {
 
         PublicKey memory pk = sk.toPublicKey();
         assertTrue(
-            pk.verify(
-                Message.deriveEthereumSignedMessageHash(message), sig1
-            )
+            pk.verify(Message.deriveEthereumSignedMessageHash(message), sig1)
         );
         assertTrue(
             pk.verify(
@@ -389,11 +387,11 @@ contract ECDSAWrapper {
         return pk.verify(message, sig);
     }
 
-    function verify(
-        PublicKey memory pk,
-        bytes32 digest,
-        Signature memory sig
-    ) public pure returns (bool) {
+    function verify(PublicKey memory pk, bytes32 digest, Signature memory sig)
+        public
+        pure
+        returns (bool)
+    {
         return pk.verify(digest, sig);
     }
 
@@ -432,10 +430,11 @@ contract ECDSAWrapper {
         return sk.sign(digest);
     }
 
-    function signEthereumSignedMessageHash(
-        SecretKey sk,
-        bytes memory message
-    ) public view returns (Signature memory) {
+    function signEthereumSignedMessageHash(SecretKey sk, bytes memory message)
+        public
+        view
+        returns (Signature memory)
+    {
         return sk.signEthereumSignedMessageHash(message);
     }
 

--- a/test/signatures/ECDSA.t.sol
+++ b/test/signatures/ECDSA.t.sol
@@ -7,7 +7,7 @@ import {console2 as console} from "forge-std/console2.sol";
 import {ECDSA, Signature} from "src/signatures/ECDSA.sol";
 import {ECDSAUnsafe} from "unsafe/ECDSAUnsafe.sol";
 
-import {Secp256k1, PrivateKey, PublicKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1, SecretKey, PublicKey} from "src/curves/Secp256k1.sol";
 
 import {Message} from "src/Message.sol";
 
@@ -15,14 +15,15 @@ import {Message} from "src/Message.sol";
  * @notice ECDSA Unit Tests
  */
 contract ECDSATest is Test {
+    using Secp256k1 for SecretKey;
+    using Secp256k1 for PublicKey;
+
     using ECDSA for address;
-    using ECDSA for PrivateKey;
+    using ECDSA for SecretKey;
     using ECDSA for PublicKey;
     using ECDSA for Signature;
-    using ECDSAUnsafe for Signature;
 
-    using Secp256k1 for PrivateKey;
-    using Secp256k1 for PublicKey;
+    using ECDSAUnsafe for Signature;
 
     ECDSAWrapper wrapper;
 
@@ -33,42 +34,42 @@ contract ECDSATest is Test {
     //--------------------------------------------------------------------------
     // Test: Signature Verification
 
-    function testFuzz_verify(PrivateKey privKey, bytes memory message) public {
-        vm.assume(privKey.isValid());
+    function testFuzz_verify(SecretKey sk, bytes memory message) public {
+        vm.assume(sk.isValid());
 
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
         bytes32 digest = keccak256(message);
 
         uint8 v;
         bytes32 r;
         bytes32 s;
-        (v, r, s) = vm.sign(privKey.asUint(), digest);
+        (v, r, s) = vm.sign(sk.asUint(), digest);
 
         Signature memory sig = Signature(v, r, s);
 
-        assertTrue(wrapper.verify(pubKey, message, sig));
-        assertTrue(wrapper.verify(pubKey, digest, sig));
-        assertTrue(wrapper.verify(pubKey.toAddress(), message, sig));
-        assertTrue(wrapper.verify(pubKey.toAddress(), digest, sig));
+        assertTrue(wrapper.verify(pk, message, sig));
+        assertTrue(wrapper.verify(pk, digest, sig));
+        assertTrue(wrapper.verify(pk.toAddress(), message, sig));
+        assertTrue(wrapper.verify(pk.toAddress(), digest, sig));
     }
 
     function testFuzz_verify_FailsIf_SignatureInvalid(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message,
         uint8 vMask,
         uint rMask,
         uint sMask
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
         vm.assume(vMask != 0 || rMask != 0 || sMask != 0);
 
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
         bytes32 digest = keccak256(message);
 
         uint8 v;
         bytes32 r;
         bytes32 s;
-        (v, r, s) = vm.sign(privKey.asUint(), digest);
+        (v, r, s) = vm.sign(sk.asUint(), digest);
 
         v ^= vMask;
         r = bytes32(uint(r) ^ rMask);
@@ -79,53 +80,53 @@ contract ECDSATest is Test {
         // Note that verify() reverts if signature is malleable.
         sig.intoNonMalleable();
 
-        assertFalse(wrapper.verify(pubKey, message, sig));
-        assertFalse(wrapper.verify(pubKey, digest, sig));
-        assertFalse(wrapper.verify(pubKey.toAddress(), message, sig));
-        assertFalse(wrapper.verify(pubKey.toAddress(), digest, sig));
+        assertFalse(wrapper.verify(pk, message, sig));
+        assertFalse(wrapper.verify(pk, digest, sig));
+        assertFalse(wrapper.verify(pk.toAddress(), message, sig));
+        assertFalse(wrapper.verify(pk.toAddress(), digest, sig));
     }
 
     function testFuzz_verify_RevertsIf_SignatureMalleable(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
 
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
         bytes32 digest = keccak256(message);
 
         uint8 v;
         bytes32 r;
         bytes32 s;
-        (v, r, s) = vm.sign(privKey.asUint(), digest);
+        (v, r, s) = vm.sign(sk.asUint(), digest);
 
         Signature memory badSig = Signature(v, r, s).intoMalleable();
 
         vm.expectRevert("SignatureMalleable()");
-        wrapper.verify(pubKey, message, badSig);
+        wrapper.verify(pk, message, badSig);
 
         vm.expectRevert("SignatureMalleable()");
-        wrapper.verify(pubKey, digest, badSig);
+        wrapper.verify(pk, digest, badSig);
 
         vm.expectRevert("SignatureMalleable()");
-        wrapper.verify(pubKey.toAddress(), message, badSig);
+        wrapper.verify(pk.toAddress(), message, badSig);
 
         vm.expectRevert("SignatureMalleable()");
-        wrapper.verify(pubKey.toAddress(), digest, badSig);
+        wrapper.verify(pk.toAddress(), digest, badSig);
     }
 
     function testFuzz_verify_RevertsIf_PublicKeyInvalid(
-        PublicKey memory pubKey,
+        PublicKey memory pk,
         bytes memory message,
         Signature memory sig
     ) public {
-        vm.assume(!pubKey.isValid());
+        vm.assume(!pk.isValid());
 
         vm.expectRevert("PublicKeyInvalid()");
-        wrapper.verify(pubKey, message, sig);
+        wrapper.verify(pk, message, sig);
 
         vm.expectRevert("PublicKeyInvalid()");
-        wrapper.verify(pubKey, keccak256(message), sig);
+        wrapper.verify(pk, keccak256(message), sig);
     }
 
     function testFuzz_verify_RevertsIf_SignerZeroAddress(
@@ -144,74 +145,74 @@ contract ECDSATest is Test {
     //--------------------------------------------------------------------------
     // Test: Signature Creation
 
-    function testFuzz_sign(PrivateKey privKey, bytes memory message) public {
-        vm.assume(privKey.isValid());
+    function testFuzz_sign(SecretKey sk, bytes memory message) public {
+        vm.assume(sk.isValid());
 
-        Signature memory sig1 = wrapper.sign(privKey, message);
-        Signature memory sig2 = wrapper.sign(privKey, keccak256(message));
+        Signature memory sig1 = wrapper.sign(sk, message);
+        Signature memory sig2 = wrapper.sign(sk, keccak256(message));
 
         assertEq(sig1.v, sig2.v);
         assertEq(sig1.r, sig2.r);
         assertEq(sig1.s, sig2.s);
 
-        PublicKey memory pubKey = privKey.toPublicKey();
-        assertTrue(pubKey.verify(message, sig1));
-        assertTrue(pubKey.verify(message, sig2));
+        PublicKey memory pk = sk.toPublicKey();
+        assertTrue(pk.verify(message, sig1));
+        assertTrue(pk.verify(message, sig2));
     }
 
-    function testFuzz_sign_RevertsIf_PrivateKeyInvalid(
-        PrivateKey privKey,
+    function testFuzz_sign_RevertsIf_SecretKeyInvalid(
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(!privKey.isValid());
+        vm.assume(!sk.isValid());
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.sign(privKey, message);
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.sign(sk, message);
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.sign(privKey, keccak256(message));
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.sign(sk, keccak256(message));
     }
 
     function testFuzz_signEthereumSignedMessageHash(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
 
         Signature memory sig1 =
-            wrapper.signEthereumSignedMessageHash(privKey, message);
+            wrapper.signEthereumSignedMessageHash(sk, message);
         Signature memory sig2 =
-            wrapper.signEthereumSignedMessageHash(privKey, keccak256(message));
+            wrapper.signEthereumSignedMessageHash(sk, keccak256(message));
 
         assertEq(sig1.v, sig2.v);
         assertEq(sig1.r, sig2.r);
         assertEq(sig1.s, sig2.s);
 
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
         assertTrue(
-            pubKey.verify(
+            pk.verify(
                 Message.deriveEthereumSignedMessageHash(message), sig1
             )
         );
         assertTrue(
-            pubKey.verify(
+            pk.verify(
                 Message.deriveEthereumSignedMessageHash(keccak256(message)),
                 sig2
             )
         );
     }
 
-    function testFuzz_signEthereumSignedMessageHash_RevertsIf_PrivateKeyInvalid(
-        PrivateKey privKey,
+    function testFuzz_signEthereumSignedMessageHash_RevertsIf_SecretKeyInvalid(
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(!privKey.isValid());
+        vm.assume(!sk.isValid());
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.signEthereumSignedMessageHash(privKey, message);
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.signEthereumSignedMessageHash(sk, message);
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.signEthereumSignedMessageHash(privKey, keccak256(message));
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.signEthereumSignedMessageHash(sk, keccak256(message));
     }
 
     //--------------------------------------------------------------------------
@@ -367,32 +368,33 @@ contract ECDSATest is Test {
  * @dev For more info, see https://github.com/foundry-rs/foundry/pull/3128#issuecomment-1241245086.
  */
 contract ECDSAWrapper {
+    using Secp256k1 for SecretKey;
+    using Secp256k1 for PublicKey;
+
     using ECDSA for address;
-    using ECDSA for PrivateKey;
+    using ECDSA for SecretKey;
     using ECDSA for PublicKey;
     using ECDSA for Signature;
-    using ECDSAUnsafe for Signature;
 
-    using Secp256k1 for PrivateKey;
-    using Secp256k1 for PublicKey;
+    using ECDSAUnsafe for Signature;
 
     //--------------------------------------------------------------------------
     // Signature Verification
 
     function verify(
-        PublicKey memory pubKey,
+        PublicKey memory pk,
         bytes memory message,
         Signature memory sig
     ) public pure returns (bool) {
-        return pubKey.verify(message, sig);
+        return pk.verify(message, sig);
     }
 
     function verify(
-        PublicKey memory pubKey,
+        PublicKey memory pk,
         bytes32 digest,
         Signature memory sig
     ) public pure returns (bool) {
-        return pubKey.verify(digest, sig);
+        return pk.verify(digest, sig);
     }
 
     function verify(address signer, bytes memory message, Signature memory sig)
@@ -414,35 +416,35 @@ contract ECDSAWrapper {
     //--------------------------------------------------------------------------
     // Signature Creation
 
-    function sign(PrivateKey privKey, bytes memory message)
+    function sign(SecretKey sk, bytes memory message)
         public
         view
         returns (Signature memory)
     {
-        return privKey.sign(message);
+        return sk.sign(message);
     }
 
-    function sign(PrivateKey privKey, bytes32 digest)
+    function sign(SecretKey sk, bytes32 digest)
         public
         view
         returns (Signature memory)
     {
-        return privKey.sign(digest);
+        return sk.sign(digest);
     }
 
     function signEthereumSignedMessageHash(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public view returns (Signature memory) {
-        return privKey.signEthereumSignedMessageHash(message);
+        return sk.signEthereumSignedMessageHash(message);
     }
 
-    function signEthereumSignedMessageHash(PrivateKey privKey, bytes32 digest)
+    function signEthereumSignedMessageHash(SecretKey sk, bytes32 digest)
         public
         view
         returns (Signature memory)
     {
-        return privKey.signEthereumSignedMessageHash(digest);
+        return sk.signEthereumSignedMessageHash(digest);
     }
 
     //--------------------------------------------------------------------------

--- a/test/signatures/Schnorr.t.sol
+++ b/test/signatures/Schnorr.t.sol
@@ -75,9 +75,7 @@ contract SchnorrTest is Test {
         );
         vm.expectRevert("PublicKeyInvalid()");
         wrapper.verify(
-            pk,
-            keccak256(message),
-            Secp256k1.secretKeyFromUint(1).sign(message)
+            pk, keccak256(message), Secp256k1.secretKeyFromUint(1).sign(message)
         );
     }
 
@@ -162,14 +160,10 @@ contract SchnorrTest is Test {
 
         PublicKey memory pk = sk.toPublicKey();
         assertTrue(
-            pk.verify(
-                Message.deriveEthereumSignedMessageHash(message), sig1
-            )
+            pk.verify(Message.deriveEthereumSignedMessageHash(message), sig1)
         );
         assertTrue(
-            pk.verify(
-                Message.deriveEthereumSignedMessageHash(message), sig2
-            )
+            pk.verify(Message.deriveEthereumSignedMessageHash(message), sig2)
         );
     }
 
@@ -247,11 +241,11 @@ contract SchnorrWrapper {
         return pk.verify(message, sig);
     }
 
-    function verify(
-        PublicKey memory pk,
-        bytes32 digest,
-        Signature memory sig
-    ) public pure returns (bool) {
+    function verify(PublicKey memory pk, bytes32 digest, Signature memory sig)
+        public
+        pure
+        returns (bool)
+    {
         return pk.verify(digest, sig);
     }
 
@@ -272,10 +266,10 @@ contract SchnorrWrapper {
         return sk.sign(digest);
     }
 
-    function signEthereumSignedMessageHash(
-        SecretKey sk,
-        bytes memory message
-    ) public returns (Signature memory) {
+    function signEthereumSignedMessageHash(SecretKey sk, bytes memory message)
+        public
+        returns (Signature memory)
+    {
         return sk.signEthereumSignedMessageHash(message);
     }
 

--- a/test/signatures/Schnorr.t.sol
+++ b/test/signatures/Schnorr.t.sol
@@ -6,7 +6,7 @@ import {console2 as console} from "forge-std/console2.sol";
 
 import {Schnorr, Signature} from "src/signatures/Schnorr.sol";
 
-import {Secp256k1, PrivateKey, PublicKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1, SecretKey, PublicKey} from "src/curves/Secp256k1.sol";
 
 import {Message} from "src/Message.sol";
 
@@ -14,12 +14,12 @@ import {Message} from "src/Message.sol";
  * @notice Schnorr Unit Tests
  */
 contract SchnorrTest is Test {
-    using Schnorr for PrivateKey;
+    using Secp256k1 for SecretKey;
+    using Secp256k1 for PublicKey;
+
+    using Schnorr for SecretKey;
     using Schnorr for PublicKey;
     using Schnorr for Signature;
-
-    using Secp256k1 for PrivateKey;
-    using Secp256k1 for PublicKey;
 
     SchnorrWrapper wrapper;
 
@@ -30,26 +30,26 @@ contract SchnorrTest is Test {
     //--------------------------------------------------------------------------
     // Test: Signature Verification
 
-    function testFuzz_verify(PrivateKey privKey, bytes memory message) public {
-        vm.assume(privKey.isValid());
+    function testFuzz_verify(SecretKey sk, bytes memory message) public {
+        vm.assume(sk.isValid());
 
-        Signature memory sig = privKey.sign(message);
+        Signature memory sig = sk.sign(message);
 
-        PublicKey memory pubKey = privKey.toPublicKey();
-        assertTrue(wrapper.verify(pubKey, message, sig));
-        assertTrue(wrapper.verify(pubKey, keccak256(message), sig));
+        PublicKey memory pk = sk.toPublicKey();
+        assertTrue(wrapper.verify(pk, message, sig));
+        assertTrue(wrapper.verify(pk, keccak256(message), sig));
     }
 
     function testFuzz_verify_FailsIf_SignatureInvalid(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message,
         uint signatureMask,
         uint160 commitmentMask
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
         vm.assume(signatureMask != 0 || commitmentMask != 0);
 
-        Signature memory sig = privKey.sign(message);
+        Signature memory sig = sk.sign(message);
 
         sig.signature = bytes32(uint(sig.signature) ^ signatureMask);
         sig.commitment = address(uint160(sig.commitment) ^ commitmentMask);
@@ -58,132 +58,132 @@ contract SchnorrTest is Test {
         vm.assume(!sig.isMalleable());
         vm.assume(sig.signature != 0 || sig.commitment != address(0));
 
-        PublicKey memory pubKey = privKey.toPublicKey();
-        assertFalse(wrapper.verify(pubKey, message, sig));
-        assertFalse(wrapper.verify(pubKey, keccak256(message), sig));
+        PublicKey memory pk = sk.toPublicKey();
+        assertFalse(wrapper.verify(pk, message, sig));
+        assertFalse(wrapper.verify(pk, keccak256(message), sig));
     }
 
     function testFuzz_verify_RevertsIf_PublicKeyInvalid(
-        PublicKey memory pubKey,
+        PublicKey memory pk,
         bytes memory message
     ) public {
-        vm.assume(!pubKey.isValid());
+        vm.assume(!pk.isValid());
 
         vm.expectRevert("PublicKeyInvalid()");
         wrapper.verify(
-            pubKey, message, Secp256k1.privateKeyFromUint(1).sign(message)
+            pk, message, Secp256k1.secretKeyFromUint(1).sign(message)
         );
         vm.expectRevert("PublicKeyInvalid()");
         wrapper.verify(
-            pubKey,
+            pk,
             keccak256(message),
-            Secp256k1.privateKeyFromUint(1).sign(message)
+            Secp256k1.secretKeyFromUint(1).sign(message)
         );
     }
 
     function testFuzz_verify_RevertsIf_SignatureMalleable(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message,
         Signature memory sig
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
         vm.assume(sig.commitment != address(0));
 
         sig.signature =
             bytes32(_bound(uint(sig.signature), Secp256k1.Q, type(uint).max));
 
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
 
         vm.expectRevert("SignatureMalleable()");
-        wrapper.verify(pubKey, message, sig);
+        wrapper.verify(pk, message, sig);
         vm.expectRevert("SignatureMalleable()");
-        wrapper.verify(pubKey, keccak256(message), sig);
+        wrapper.verify(pk, keccak256(message), sig);
     }
 
     function testFuzz_verify_RevertsIf_SignatureTrivial(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
 
         Signature memory sig = Signature(0, address(0));
 
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
 
         vm.expectRevert("SignatureTrivial()");
-        wrapper.verify(pubKey, message, sig);
+        wrapper.verify(pk, message, sig);
         vm.expectRevert("SignatureTrivial()");
-        wrapper.verify(pubKey, keccak256(message), sig);
+        wrapper.verify(pk, keccak256(message), sig);
     }
 
     //--------------------------------------------------------------------------
     // Test: Signature Creation
 
-    function testFuzz_sign(PrivateKey privKey, bytes memory message) public {
-        vm.assume(privKey.isValid());
+    function testFuzz_sign(SecretKey sk, bytes memory message) public {
+        vm.assume(sk.isValid());
 
-        Signature memory sig1 = wrapper.sign(privKey, message);
-        Signature memory sig2 = wrapper.sign(privKey, keccak256(message));
+        Signature memory sig1 = wrapper.sign(sk, message);
+        Signature memory sig2 = wrapper.sign(sk, keccak256(message));
 
         assertEq(sig1.signature, sig2.signature);
         assertEq(sig1.commitment, sig2.commitment);
 
-        PublicKey memory pubKey = privKey.toPublicKey();
-        assertTrue(pubKey.verify(message, sig1));
-        assertTrue(pubKey.verify(message, sig2));
+        PublicKey memory pk = sk.toPublicKey();
+        assertTrue(pk.verify(message, sig1));
+        assertTrue(pk.verify(message, sig2));
     }
 
-    function testFuzz_sign_RevertsIf_PrivateKeyInvalid(
-        PrivateKey privKey,
+    function testFuzz_sign_RevertsIf_SecretKeyInvalid(
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(!privKey.isValid());
+        vm.assume(!sk.isValid());
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.sign(privKey, message);
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.sign(sk, message);
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.sign(privKey, keccak256(message));
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.sign(sk, keccak256(message));
     }
 
     function testFuzz_signEthereumSignedMessageHash(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
 
         Signature memory sig1 =
-            wrapper.signEthereumSignedMessageHash(privKey, message);
+            wrapper.signEthereumSignedMessageHash(sk, message);
         Signature memory sig2 =
-            wrapper.signEthereumSignedMessageHash(privKey, keccak256(message));
+            wrapper.signEthereumSignedMessageHash(sk, keccak256(message));
 
         assertEq(sig1.signature, sig2.signature);
         assertEq(sig1.commitment, sig2.commitment);
 
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
         assertTrue(
-            pubKey.verify(
+            pk.verify(
                 Message.deriveEthereumSignedMessageHash(message), sig1
             )
         );
         assertTrue(
-            pubKey.verify(
+            pk.verify(
                 Message.deriveEthereumSignedMessageHash(message), sig2
             )
         );
     }
 
-    function testFuzz_signEthereumSignedMessageHash_RevertsIf_PrivateKeyInvalid(
-        PrivateKey privKey,
+    function testFuzz_signEthereumSignedMessageHash_RevertsIf_SecretKeyInvalid(
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(!privKey.isValid());
+        vm.assume(!sk.isValid());
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.signEthereumSignedMessageHash(privKey, message);
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.signEthereumSignedMessageHash(sk, message);
 
-        vm.expectRevert("PrivateKeyInvalid()");
-        wrapper.signEthereumSignedMessageHash(privKey, keccak256(message));
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.signEthereumSignedMessageHash(sk, keccak256(message));
     }
 
     //--------------------------------------------------------------------------
@@ -232,7 +232,7 @@ contract SchnorrTest is Test {
  * @dev For more info, see https://github.com/foundry-rs/foundry/pull/3128#issuecomment-1241245086.
  */
 contract SchnorrWrapper {
-    using Schnorr for PrivateKey;
+    using Schnorr for SecretKey;
     using Schnorr for PublicKey;
     using Schnorr for Signature;
 
@@ -240,50 +240,50 @@ contract SchnorrWrapper {
     // Signature Verification
 
     function verify(
-        PublicKey memory pubKey,
+        PublicKey memory pk,
         bytes memory message,
         Signature memory sig
     ) public pure returns (bool) {
-        return pubKey.verify(message, sig);
+        return pk.verify(message, sig);
     }
 
     function verify(
-        PublicKey memory pubKey,
+        PublicKey memory pk,
         bytes32 digest,
         Signature memory sig
     ) public pure returns (bool) {
-        return pubKey.verify(digest, sig);
+        return pk.verify(digest, sig);
     }
 
     //--------------------------------------------------------------------------
     // Signature Creation
 
-    function sign(PrivateKey privKey, bytes memory message)
+    function sign(SecretKey sk, bytes memory message)
         public
         returns (Signature memory)
     {
-        return privKey.sign(message);
+        return sk.sign(message);
     }
 
-    function sign(PrivateKey privKey, bytes32 digest)
+    function sign(SecretKey sk, bytes32 digest)
         public
         returns (Signature memory)
     {
-        return privKey.sign(digest);
+        return sk.sign(digest);
     }
 
     function signEthereumSignedMessageHash(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public returns (Signature memory) {
-        return privKey.signEthereumSignedMessageHash(message);
+        return sk.signEthereumSignedMessageHash(message);
     }
 
-    function signEthereumSignedMessageHash(PrivateKey privKey, bytes32 digest)
+    function signEthereumSignedMessageHash(SecretKey sk, bytes32 digest)
         public
         returns (Signature memory)
     {
-        return privKey.signEthereumSignedMessageHash(digest);
+        return sk.signEthereumSignedMessageHash(digest);
     }
 
     //--------------------------------------------------------------------------

--- a/test/signatures/SchnorrProperties.t.sol
+++ b/test/signatures/SchnorrProperties.t.sol
@@ -6,52 +6,53 @@ import {console2 as console} from "forge-std/console2.sol";
 
 import {Schnorr, Signature} from "src/signatures/Schnorr.sol";
 
-import {Secp256k1, PrivateKey, PublicKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1, SecretKey, PublicKey} from "src/curves/Secp256k1.sol";
 
 /**
  * @notice Schnorr Property Tests
  */
 contract SchnorrPropertiesTest is Test {
-    using Schnorr for PrivateKey;
+    using Schnorr for SecretKey;
     using Schnorr for PublicKey;
     using Schnorr for Signature;
 
-    using Secp256k1 for PrivateKey;
+    using Secp256k1 for SecretKey;
 
     //--------------------------------------------------------------------------
     // Properties: Signature
 
     function testProperty_sign_CreatesVerifiableSignatures(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
 
-        PublicKey memory pubKey = privKey.toPublicKey();
+        PublicKey memory pk = sk.toPublicKey();
+        Signature memory sig = sk.sign(message);
 
-        assertTrue(pubKey.verify(message, privKey.sign(message)));
+        assertTrue(pk.verify(message, sig));
     }
 
     function testProperty_sign_CreatesDeterministicSignatures(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
 
-        Signature memory sig1 = privKey.sign(message);
-        Signature memory sig2 = privKey.sign(message);
+        Signature memory sig1 = sk.sign(message);
+        Signature memory sig2 = sk.sign(message);
 
         assertEq(sig1.signature, sig2.signature);
         assertEq(sig1.commitment, sig2.commitment);
     }
 
     function testProperty_sign_CreatesNonMalleableSignatures(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
 
-        assertFalse(privKey.sign(message).isMalleable());
+        assertFalse(sk.sign(message).isMalleable());
     }
 
     //--------------------------------------------------------------------------

--- a/test/signatures/utils/Nonce.t.sol
+++ b/test/signatures/utils/Nonce.t.sol
@@ -6,14 +6,14 @@ import {console2 as console} from "forge-std/console2.sol";
 
 import {Nonce} from "src/signatures/utils/Nonce.sol";
 
-import {Secp256k1, PrivateKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1, SecretKey} from "src/curves/Secp256k1.sol";
 
 /**
  * @notice Nonce Unit Tests
  */
 contract NonceTest is Test {
-    using Nonce for PrivateKey;
-    using Secp256k1 for PrivateKey;
+    using Nonce for SecretKey;
+    using Secp256k1 for SecretKey;
 
     NonceWrapper wrapper;
 
@@ -22,23 +22,23 @@ contract NonceTest is Test {
     }
 
     function testFuzz_deriveNonce_IsDeterministic(
-        PrivateKey privKey,
+        SecretKey sk,
         bytes memory message
     ) public {
-        vm.assume(privKey.isValid());
+        vm.assume(sk.isValid());
 
         uint nonce1;
         uint nonce2;
 
         // Using deriveNonce from message.
-        nonce1 = wrapper.deriveNonce(privKey, message);
-        nonce2 = wrapper.deriveNonce(privKey, message);
+        nonce1 = wrapper.deriveNonce(sk, message);
+        nonce2 = wrapper.deriveNonce(sk, message);
         assertEq(nonce1, nonce2);
 
         // Using deriveNonce from digest.
         bytes32 digest = keccak256(message);
-        nonce1 = wrapper.deriveNonce(privKey, digest);
-        nonce2 = wrapper.deriveNonce(privKey, digest);
+        nonce1 = wrapper.deriveNonce(sk, digest);
+        nonce2 = wrapper.deriveNonce(sk, digest);
         assertEq(nonce1, nonce2);
     }
 }
@@ -49,21 +49,21 @@ contract NonceTest is Test {
  * @dev For more info, see https://github.com/foundry-rs/foundry/pull/3128#issuecomment-1241245086.
  */
 contract NonceWrapper {
-    using Nonce for PrivateKey;
+    using Nonce for SecretKey;
 
-    function deriveNonce(PrivateKey privKey, bytes memory message)
+    function deriveNonce(SecretKey sk, bytes memory message)
         public
         pure
         returns (uint)
     {
-        return privKey.deriveNonce(message);
+        return sk.deriveNonce(message);
     }
 
-    function deriveNonce(PrivateKey privKey, bytes32 digest)
+    function deriveNonce(SecretKey sk, bytes32 digest)
         public
         pure
         returns (uint)
     {
-        return privKey.deriveNonce(digest);
+        return sk.deriveNonce(digest);
     }
 }

--- a/unsafe/ECDSAUnsafe.sol
+++ b/unsafe/ECDSAUnsafe.sol
@@ -12,7 +12,7 @@
 pragma solidity ^0.8.16;
 
 import {ECDSA, Signature} from "src/signatures/ECDSA.sol";
-import {Secp256k1, PrivateKey, PublicKey} from "src/curves/Secp256k1.sol";
+import {Secp256k1} from "src/curves/Secp256k1.sol";
 import {Secp256k1Arithmetic} from "src/curves/Secp256k1Arithmetic.sol";
 
 /**
@@ -24,45 +24,42 @@ import {Secp256k1Arithmetic} from "src/curves/Secp256k1Arithmetic.sol";
  */
 library ECDSAUnsafe {
     using ECDSA for Signature;
-    using ECDSAUnsafe for PrivateKey;
 
-    using Secp256k1 for PrivateKey;
-
-    /// @dev Mutates signature `self` to be malleable.
-    function intoMalleable(Signature memory self)
+    /// @dev Mutates signature `sig` to be malleable.
+    function intoMalleable(Signature memory sig)
         internal
         pure
         returns (Signature memory)
     {
-        if (self.isMalleable()) {
-            return self;
+        if (sig.isMalleable()) {
+            return sig;
         }
 
-        // Flip self.s to Secp256k1.Q - self.s.
-        self.s = bytes32(Secp256k1.Q - uint(self.s));
+        // Flip sig.s to Secp256k1.Q - sig.s.
+        sig.s = bytes32(Secp256k1.Q - uint(sig.s));
 
         // Flip v.
-        self.v = self.v == 27 ? 28 : 27;
+        sig.v = sig.v == 27 ? 28 : 27;
 
-        return self;
+        return sig;
     }
 
-    /// @dev Mutates signature `self` to be non-malleable.
-    function intoNonMalleable(Signature memory self)
+    /// @dev Mutates signature `sig` to be non-malleable.
+    function intoNonMalleable(Signature memory sig)
         internal
         pure
         returns (Signature memory)
     {
-        if (!self.isMalleable()) {
-            return self;
+        if (!sig.isMalleable()) {
+            return sig;
         }
 
-        // Flip self.s to Secp256k1.Q - self.s.
-        self.s = bytes32(Secp256k1.Q - uint(self.s));
+        // Flip sig.s to Secp256k1.Q - sig.s.
+        sig.s = bytes32(Secp256k1.Q - uint(sig.s));
 
         // Flip v.
-        self.v = self.v == 27 ? 28 : 27;
+        sig.v = sig.v == 27 ? 28 : 27;
 
-        return self;
+        return sig;
     }
 }


### PR DESCRIPTION
Renamings:
- `PrivateKey` -> `SecretKey`
- `JacobianPoint` -> `ProjectivePoint`
- `PointAtInfinity` -> `Identity`

For more info, see RustCrypto's [`k256`](https://github.com/RustCrypto/elliptic-curves/blob/master/k256/README.md) crate.
